### PR TITLE
Python3 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,3 +19,7 @@ Then !help to see the available commands and their explanation.
 ::
     pip install feedparser
     pip install beautifulsoup
+
+In case of Python 3, you need a slightly different name.
+::
+    pip install beautifulsoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 feedparser
-beautifulsoup  
+beautifulsoup

--- a/rss_feed.plug
+++ b/rss_feed.plug
@@ -2,5 +2,8 @@
 Name = RSSFeedPlugin
 Module = rss_feed
 
+[Python]
+Version = 2+
+
 [Documentation]
 Description = rss feed.

--- a/rss_feed.py
+++ b/rss_feed.py
@@ -1,10 +1,14 @@
 from datetime import datetime
 import logging
+import sys
 
 from config import CHATROOM_PRESENCE
 from feedparser import parse
 
-from BeautifulSoup import BeautifulSoup
+if sys.version_info.major <= 2:
+    from BeautifulSoup import BeautifulSoup
+else:
+    from bs4 import BeautifulSoup
 
 # Backward compatibility
 from errbot.version import VERSION


### PR DESCRIPTION
The code seems fine for Python3. Just the import must be changed.

However, the requirements.txt file is wrong for Python3 and cannot be fixed. Since this is only used for a warning, it seems ok to me. At least the plugin works out of the box again.
